### PR TITLE
Compile regex

### DIFF
--- a/RDRsegmenter.java
+++ b/RDRsegmenter.java
@@ -2,6 +2,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -282,6 +283,9 @@ public class RDRsegmenter
             throws IOException
     {
         File directoryPath = new File(inDirectoryPath);
+        if (!directoryPath.exists()) {
+            throw new FileNotFoundException("Requested directory " + directoryPath + " does not exist!");
+        }
         FilenameFilter textFilefilter = new FilenameFilter(){
            public boolean accept(File dir, String name) {
               if (name.endsWith(suffix)) {
@@ -292,7 +296,7 @@ public class RDRsegmenter
            }
         };
         File filesList[] = directoryPath.listFiles(textFilefilter);
-        
+
         for(File file : filesList) {
             segmentRawCorpus(file.getAbsolutePath());
         }

--- a/Tokenizer.java
+++ b/Tokenizer.java
@@ -109,7 +109,7 @@ public class Tokenizer {
 				Matcher matcher = pattern.matcher(token);
 
 				if (matcher.find()) {
-					if (i == Regex.getRegexIndex("url")) {
+					if (pattern == Regex.URL_PATTERN) {
 						String[] elements = token.split(Pattern.quote("."));
 						boolean hasURL = true;
 						for (String ele : elements) {
@@ -131,7 +131,7 @@ public class Tokenizer {
 						}
 					}
 
-					else if (i == Regex.getRegexIndex("month")) {
+					else if (pattern == Regex.MONTH_PATTERN) {
 						int start = matcher.start();
 
 						boolean hasLetter = false;
@@ -479,6 +479,7 @@ class Regex
     public static final String FULL_DATE = "(0?[1-9]|[12][0-9]|3[01])(\\/|-|\\.)(1[0-2]|(0?[1-9]))((\\/|-|\\.)\\d{4})";
 
     public static final String MONTH = "(1[0-2]|(0?[1-9]))(\\/)\\d{4}";
+    public static final Pattern MONTH_PATTERN = Pattern.compile(MONTH);
 
     public static final String DATE = "(0?[1-9]|[12][0-9]|3[01])(\\/)(1[0-2]|(0?[1-9]))";
 
@@ -489,6 +490,7 @@ class Regex
     public static final String PHONE_NUMBER = "(\\(?\\+\\d{1,2}\\)?[\\s\\.-]?)?\\d{2,}[\\s\\.-]?\\d{3,}[\\s\\.-]?\\d{3,}";
 
     public static final String URL = "(((https?|ftp):\\/\\/|www\\.)[^\\s/$.?#].[^\\s]*)|(https?:\\/\\/)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)";
+    public static final Pattern URL_PATTERN = Pattern.compile(URL);
 
     public static final String NUMBER = "[-+]?\\d+([\\.,]\\d+)*%?\\p{Sc}?";
 
@@ -509,44 +511,22 @@ class Regex
     private static List<Pattern> regexes = Arrays.asList(
         Pattern.compile(ELLIPSIS),
         Pattern.compile(EMAIL),
-        Pattern.compile(URL),
+        URL_PATTERN,
         Pattern.compile(FULL_DATE),
-        Pattern.compile(MONTH),
+        MONTH_PATTERN,
         Pattern.compile(DATE),
         Pattern.compile(TIME),
         Pattern.compile(MONEY),
         Pattern.compile(PHONE_NUMBER),
-        Pattern.compile(SHORT_NAME),
+        SHORT_NAME_PATTERN,
         Pattern.compile(NUMBERS_EXPRESSION),
         Pattern.compile(NUMBER),
         Pattern.compile(PUNCTUATION),
         Pattern.compile(SPECIAL_CHAR),
         Pattern.compile(ALLCAP));
 
-    private static List<String> regexIndex = Arrays.asList(
-        "ELLIPSIS",
-        "EMAIL",
-        "URL",
-        "FULL_DATE",
-        "MONTH",
-        "DATE",
-        "TIME",
-        "MONEY",
-        "PHONE_NUMBER",
-        "SHORT_NAME",
-        "NUMBERS_EXPRESSION",
-        "NUMBER",
-        "PUNCTUATION",
-        "SPECIAL_CHAR",
-        "ALLCAP");
-
     public static List<Pattern> getRegexList()
     {
         return regexes;
-    }
-
-    public static int getRegexIndex(String regex)
-    {
-        return regexIndex.indexOf(regex.toUpperCase());
     }
 }

--- a/Tokenizer.java
+++ b/Tokenizer.java
@@ -89,11 +89,11 @@ public class Tokenizer {
 			if (tokenContainsExp)
 				continue;
 
-			List<String> regexes = Regex.getRegexList();
+			List<Pattern> regexes = Regex.getRegexList();
 
 			boolean matching = false;
-			for (String regex : regexes) {
-				if (token.matches(regex)) {
+			for (Pattern regex : regexes) {
+                                if (regex.matcher(token).matches()) {
 					tokens.add(token);
 					matching = true;
 					break;
@@ -104,7 +104,7 @@ public class Tokenizer {
 			}
 
 			for (int i = 0; i < regexes.size(); i++) {
-				Pattern pattern = Pattern.compile(regexes.get(i));
+				Pattern pattern = regexes.get(i);
 				Matcher matcher = pattern.matcher(token);
 
 				if (matcher.find()) {
@@ -504,59 +504,59 @@ class Regex
 
     public static final String ALLCAP = "[A-Z]+\\.[A-Z]+";
 
-    private static List<String> regexes = null;
+    private static List<Pattern> regexes = null;
 
     private static List<String> regexIndex = null;
 
-    public static List<String> getRegexList()
+    public static List<Pattern> getRegexList()
     {
         if (regexes == null) {
-            regexes = new ArrayList<String>();
+            regexes = new ArrayList<Pattern>();
             regexIndex = new ArrayList<String>();
 
-            regexes.add(ELLIPSIS);
+            regexes.add(Pattern.compile(ELLIPSIS));
             regexIndex.add("ELLIPSIS");
 
-            regexes.add(EMAIL);
+            regexes.add(Pattern.compile(EMAIL));
             regexIndex.add("EMAIL");
 
-            regexes.add(URL);
+            regexes.add(Pattern.compile(URL));
             regexIndex.add("URL");
 
-            regexes.add(FULL_DATE);
+            regexes.add(Pattern.compile(FULL_DATE));
             regexIndex.add("FULL_DATE");
 
-            regexes.add(MONTH);
+            regexes.add(Pattern.compile(MONTH));
             regexIndex.add("MONTH");
 
-            regexes.add(DATE);
+            regexes.add(Pattern.compile(DATE));
             regexIndex.add("DATE");
 
-            regexes.add(TIME);
+            regexes.add(Pattern.compile(TIME));
             regexIndex.add("TIME");
 
-            regexes.add(MONEY);
+            regexes.add(Pattern.compile(MONEY));
             regexIndex.add("MONEY");
 
-            regexes.add(PHONE_NUMBER);
+            regexes.add(Pattern.compile(PHONE_NUMBER));
             regexIndex.add("PHONE_NUMBER");
 
-            regexes.add(SHORT_NAME);
+            regexes.add(Pattern.compile(SHORT_NAME));
             regexIndex.add("SHORT_NAME");
 
-            regexes.add(NUMBERS_EXPRESSION);
+            regexes.add(Pattern.compile(NUMBERS_EXPRESSION));
             regexIndex.add("NUMBERS_EXPRESSION");
 
-            regexes.add(NUMBER);
+            regexes.add(Pattern.compile(NUMBER));
             regexIndex.add("NUMBER");
 
-            regexes.add(PUNCTUATION);
+            regexes.add(Pattern.compile(PUNCTUATION));
             regexIndex.add("PUNCTUATION");
 
-            regexes.add(SPECIAL_CHAR);
+            regexes.add(Pattern.compile(SPECIAL_CHAR));
             regexIndex.add("SPECIAL_CHAR");
 
-            regexes.add(ALLCAP);
+            regexes.add(Pattern.compile(ALLCAP));
             regexIndex.add("ALLCAP");
 
         }

--- a/Tokenizer.java
+++ b/Tokenizer.java
@@ -1,4 +1,3 @@
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -18,9 +17,8 @@ public class Tokenizer {
 	/**
 	 * @param s
 	 * @return List of tokens from s
-	 * @throws IOException
 	 */
-	public static List<String> tokenize(String s) throws IOException {
+	public static List<String> tokenize(String s) {
 		if (s == null || s.trim().isEmpty()) {
 			return new ArrayList<String>();
 		}
@@ -166,8 +164,7 @@ public class Tokenizer {
 		return tokens;
 	}
 
-	private static List<String> recursive(List<String> tokens, String token, int beginMatch, int endMatch)
-			throws IOException {
+	private static List<String> recursive(List<String> tokens, String token, int beginMatch, int endMatch) {
 		if (beginMatch > 0)
 			tokens.addAll(tokenize(token.substring(0, beginMatch)));
 		tokens.addAll(tokenize(token.substring(beginMatch, endMatch)));

--- a/Tokenizer.java
+++ b/Tokenizer.java
@@ -1,5 +1,6 @@
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -504,63 +505,42 @@ class Regex
 
     public static final String ALLCAP = "[A-Z]+\\.[A-Z]+";
 
-    private static List<Pattern> regexes = null;
+    private static List<Pattern> regexes = Arrays.asList(
+        Pattern.compile(ELLIPSIS),
+        Pattern.compile(EMAIL),
+        Pattern.compile(URL),
+        Pattern.compile(FULL_DATE),
+        Pattern.compile(MONTH),
+        Pattern.compile(DATE),
+        Pattern.compile(TIME),
+        Pattern.compile(MONEY),
+        Pattern.compile(PHONE_NUMBER),
+        Pattern.compile(SHORT_NAME),
+        Pattern.compile(NUMBERS_EXPRESSION),
+        Pattern.compile(NUMBER),
+        Pattern.compile(PUNCTUATION),
+        Pattern.compile(SPECIAL_CHAR),
+        Pattern.compile(ALLCAP));
 
-    private static List<String> regexIndex = null;
+    private static List<String> regexIndex = Arrays.asList(
+        "ELLIPSIS",
+        "EMAIL",
+        "URL",
+        "FULL_DATE",
+        "MONTH",
+        "DATE",
+        "TIME",
+        "MONEY",
+        "PHONE_NUMBER",
+        "SHORT_NAME",
+        "NUMBERS_EXPRESSION",
+        "NUMBER",
+        "PUNCTUATION",
+        "SPECIAL_CHAR",
+        "ALLCAP");
 
     public static List<Pattern> getRegexList()
     {
-        if (regexes == null) {
-            regexes = new ArrayList<Pattern>();
-            regexIndex = new ArrayList<String>();
-
-            regexes.add(Pattern.compile(ELLIPSIS));
-            regexIndex.add("ELLIPSIS");
-
-            regexes.add(Pattern.compile(EMAIL));
-            regexIndex.add("EMAIL");
-
-            regexes.add(Pattern.compile(URL));
-            regexIndex.add("URL");
-
-            regexes.add(Pattern.compile(FULL_DATE));
-            regexIndex.add("FULL_DATE");
-
-            regexes.add(Pattern.compile(MONTH));
-            regexIndex.add("MONTH");
-
-            regexes.add(Pattern.compile(DATE));
-            regexIndex.add("DATE");
-
-            regexes.add(Pattern.compile(TIME));
-            regexIndex.add("TIME");
-
-            regexes.add(Pattern.compile(MONEY));
-            regexIndex.add("MONEY");
-
-            regexes.add(Pattern.compile(PHONE_NUMBER));
-            regexIndex.add("PHONE_NUMBER");
-
-            regexes.add(Pattern.compile(SHORT_NAME));
-            regexIndex.add("SHORT_NAME");
-
-            regexes.add(Pattern.compile(NUMBERS_EXPRESSION));
-            regexIndex.add("NUMBERS_EXPRESSION");
-
-            regexes.add(Pattern.compile(NUMBER));
-            regexIndex.add("NUMBER");
-
-            regexes.add(Pattern.compile(PUNCTUATION));
-            regexIndex.add("PUNCTUATION");
-
-            regexes.add(Pattern.compile(SPECIAL_CHAR));
-            regexIndex.add("SPECIAL_CHAR");
-
-            regexes.add(Pattern.compile(ALLCAP));
-            regexIndex.add("ALLCAP");
-
-        }
-
         return regexes;
     }
 

--- a/Tokenizer.java
+++ b/Tokenizer.java
@@ -104,8 +104,7 @@ public class Tokenizer {
 				continue;
 			}
 
-			for (int i = 0; i < regexes.size(); i++) {
-				Pattern pattern = regexes.get(i);
+			for (Pattern pattern : regexes) {
 				Matcher matcher = pattern.matcher(token);
 
 				if (matcher.find()) {

--- a/Tokenizer.java
+++ b/Tokenizer.java
@@ -50,7 +50,7 @@ public class Tokenizer {
 			}
 
 			if (token.endsWith(".") && Character.isAlphabetic(token.charAt(token.length() - 2))) {
-				if ((token.length() == 2 && Character.isUpperCase(token.charAt(token.length() - 2))) || (Pattern.compile(Regex.SHORT_NAME).matcher(token).find())) {
+				if ((token.length() == 2 && Character.isUpperCase(token.charAt(token.length() - 2))) || (Regex.SHORT_NAME_PATTERN.matcher(token).find())) {
 					tokens.add(token);
 					continue;
 				}
@@ -502,6 +502,7 @@ class Regex
 
     //public static final String SHORT_NAME = "[\\p{Upper}]\\.([\\p{L}\\p{Upper}])*";
     public static final String SHORT_NAME = "([\\p{L}]+([\\.\\-][\\p{L}]+)+)|([\\p{L}]+-\\d+)";
+    public static final Pattern SHORT_NAME_PATTERN = Pattern.compile(SHORT_NAME);
 
     public static final String ALLCAP = "[A-Z]+\\.[A-Z]+";
 

--- a/Tokenizer.java
+++ b/Tokenizer.java
@@ -44,7 +44,7 @@ public class Tokenizer {
 				continue;
 			}
 
-            if (StringUtils.VN_abbreviation.contains(token)) {
+			if (StringUtils.VN_abbreviation.contains(token)) {
 				tokens.add(token);
 				continue;
 			}
@@ -59,13 +59,13 @@ public class Tokenizer {
 				continue;
 			}
 
-            if (StringUtils.VN_exception.contains(token)) {
+			if (StringUtils.VN_exception.contains(token)) {
 				tokens.add(token);
 				continue;
 			}
 
 			boolean tokenContainsAbb = false;
-            for (String e : StringUtils.VN_abbreviation) {
+			for (String e : StringUtils.VN_abbreviation) {
 				int i = token.indexOf(e);
 				if (i < 0)
 					continue;
@@ -78,7 +78,7 @@ public class Tokenizer {
 				continue;
 
 			boolean tokenContainsExp = false;
-            for (String e : StringUtils.VN_exception) {
+			for (String e : StringUtils.VN_exception) {
 				int i = token.indexOf(e);
 				if (i < 0)
 					continue;
@@ -94,7 +94,7 @@ public class Tokenizer {
 
 			boolean matching = false;
 			for (Pattern regex : regexes) {
-                                if (regex.matcher(token).matches()) {
+				if (regex.matcher(token).matches()) {
 					tokens.add(token);
 					matching = true;
 					break;


### PR DESCRIPTION
Precompiling regex expressions makes the overall runtime significantly faster.  I ran several trials on 200K lines, and got the following average times:

89s for the original version
77s for the version with the regex compiled in an array
71.2s for the version with SHORT_NAME compiled as well
69.4s for the version with no regex lookup table either

Also included are a change to make the exception for a missing directory more user friendly and a change to make the Regex initialization thread-safe.